### PR TITLE
iOS Safari fixes

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tezos-data-backend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Tezos data fetching APIs for dashboard.",
   "type": "module",
   "main": "tasks.js",

--- a/frontend/esbuild.config.js
+++ b/frontend/esbuild.config.js
@@ -63,7 +63,7 @@ esbuild.build({
   platform: 'neutral',
   format: 'esm',
   bundle: true,
-  external: [ './tezos-widgets.js' ], // separate dashboard and widget API JavaScript
+  external: [ `./tezos-widgets.js?v${ tokens.meta.version }` ], // separate dashboard and widget API JavaScript
   minify: productionMode,
   sourcemap: !productionMode && 'linked',
   mainFields: ['module', 'browser', 'main'],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tezos-dashboard",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Tezos configurable statistics dashboard.",
   "type": "module",
   "main": "index.js",

--- a/frontend/src/js/dash/config.js
+++ b/frontend/src/js/dash/config.js
@@ -377,6 +377,7 @@ const actionHandler = {
 const observer = new MutationObserver( util.debounce( () => {
 
   dashboard.state.widgets = dashboard.container.innerHTML;
+  dashboard.state.syncState(); // required for iOS/Safari
 
 }, 1000) );
 observer.observe(dashboard.container, { attributes: true, childList: true, subtree: true });

--- a/frontend/src/js/dashboard.js
+++ b/frontend/src/js/dashboard.js
@@ -1,5 +1,5 @@
 // Tezos widget import
-import { stateZ, tezosReducer, observeReducers, TezosWidget, util } from './tezos-widgets.js';
+import { stateZ, tezosReducer, observeReducers, TezosWidget, util } from './tezos-widgets.js?v__meta_version__';
 
 // configuration panel
 import './dash/config.js';

--- a/frontend/src/js/tezos/tezos-reducer.js
+++ b/frontend/src/js/tezos/tezos-reducer.js
@@ -98,6 +98,8 @@ async function reducerFetch( reducers ) {
       state[ prop ] = update[ prop ];
     }
 
+    state.syncState(); // required for iOS/Safari
+
   }
   catch(e) {}
 

--- a/frontend/src/js/tezos/tezos-widget.js
+++ b/frontend/src/js/tezos/tezos-widget.js
@@ -184,6 +184,11 @@ export class TezosWidget extends HTMLElement {
 
     this.postRender( this.#renderIteration++, propChange, dataChange );
 
+    // set tabindex on child nodes (necessary for iOS)
+    Array.from(this.shadow.children).forEach(c => {
+      c.setAttribute('tabindex', '0');
+    });
+
   }
 
 

--- a/frontend/src/scss/03-generic/_reset.scss
+++ b/frontend/src/scss/03-generic/_reset.scss
@@ -6,6 +6,27 @@
   user-select: none;
 }
 
+// Firefox scrollbars
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--tz-color-info0) var(--tz-color-back1);
+}
+
+// other scrollbars
+::-webkit-scrollbar {
+  width: 11px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--tz-color-back1);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--tz-color-info0);
+  border-radius: 10px;
+  border: 3px solid var(--tz-color-back1);
+}
+
 template {
   display: none;
 }

--- a/frontend/src/scss/04-elements/_form.scss
+++ b/frontend/src/scss/04-elements/_form.scss
@@ -14,7 +14,6 @@ input, output, textarea, select, button {
   font-size: 1em;
   color: var(--tz-color-fore0);
   background: var(--tz-color-back2);
-  accent-color: var(--tz-color-back2);
   border: 0 none;
   outline: 0 none;
 
@@ -26,4 +25,5 @@ input, output, textarea, select, button {
 input[type="checkbox"], input[type="radio"] {
   width: auto;
   height: auto;
+  accent-color: var(--tz-color-back2);
 }

--- a/frontend/src/scss/06-components/_dashconfig.scss
+++ b/frontend/src/scss/06-components/_dashconfig.scss
@@ -111,6 +111,10 @@
   overflow: auto;
   outline: 0 none;
 
+  & > :not([hidden]) + :not(:where(input, select)) {
+    margin-top: 1em;
+  }
+
   :first-child {
     margin-top: 0;
   }
@@ -119,10 +123,6 @@
 #dashconfig-panel:focus, #dashconfig-panel:focus-within,
 #dashconfig:checked ~ #dashconfig-panel {
   transform: translateX(0%);
-}
-
-#dashconfig-add {
-  margin-top: 1em;
 }
 
 // widget list and clickable elements

--- a/frontend/src/scss/tezos-widget-base.scss
+++ b/frontend/src/scss/tezos-widget-base.scss
@@ -41,7 +41,6 @@ input, output, textarea, select, button {
   max-width: 100%;
   color: var(--tz-color-fore0);
   background: var(--tz-color-back2);
-  accent-color: var(--tz-color-back2);
   border: 0 none;
   outline: 0 none;
 
@@ -76,6 +75,7 @@ input[type="checkbox"], input[type="radio"] {
   justify-self: end;
   width: 0.8em;
   height: 0.8em;
+  accent-color: var(--tz-color-back2);
 
   & + label {
     grid-column: 3 / 4;
@@ -133,6 +133,8 @@ progress::-moz-progress-bar {
 
 // SVGs
 svg {
+
+  outline: 0 none;
 
   .line, .area, .grid {
     stroke: var(--tz-color-info1);
@@ -244,6 +246,8 @@ svg {
 // widget configuration panel
 .configpanel {
   position: fixed;
+  width: 15em;
+  max-width: 90%;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
Safari is super annoying.

* widget focus only works when tabindex="0" is applied to element and ALL children 
* beforeunload event fails - state is manually saved
* accent-color was applying to non-checkboxes and making field/select text invisible

Also styled scrollbars.